### PR TITLE
Force NSTStreetView relayout to correctly display Google attribution text and image

### DIFF
--- a/android/src/main/java/co/il/nester/android/react/streetview/NSTStreetView.java
+++ b/android/src/main/java/co/il/nester/android/react/streetview/NSTStreetView.java
@@ -37,6 +37,25 @@ public class NSTStreetView extends StreetViewPanoramaView implements OnStreetVie
         super.getStreetViewPanoramaAsync(this);
     }
 
+    private final Runnable measureAndLayout = new Runnable() {
+        @Override
+        public void run() {
+          measure(
+              MeasureSpec.makeMeasureSpec(getWidth(), MeasureSpec.EXACTLY),
+              MeasureSpec.makeMeasureSpec(getHeight(), MeasureSpec.EXACTLY));
+          layout(getLeft(), getTop(), getRight(), getBottom());
+        }
+      };
+
+    @Override
+    public void requestLayout() {
+      super.requestLayout();
+  
+      // Required for correct requestLayout
+      // H/T https://github.com/facebook/react-native/issues/4990#issuecomment-180415510
+      post(measureAndLayout);
+    }
+
     @Override
     public void onStreetViewPanoramaReady(StreetViewPanorama panorama) {
 


### PR DESCRIPTION
Cherry picked changes that cause the Google attributions (logo, report text, etc.) to be displayed over StreetView images on Android. H/T https://github.com/facebook/react-native/issues/4990#issuecomment-180415510