### PR TITLE
Fix black screen when radius not defined on iOS

### DIFF
--- a/ios/NSTStreetViewManager.m
+++ b/ios/NSTStreetViewManager.m
@@ -22,6 +22,9 @@ RCT_EXPORT_MODULE()
 RCT_CUSTOM_VIEW_PROPERTY(coordinate, CLLocationCoordinate, NSTStreetView) {
   if (json == nil) return;
   NSInteger radius = [[json valueForKey:@"radius"] intValue];
+  if(radius == 0){
+    radius = 50;
+  }
 
   [view moveNearCoordinate:[RCTConvert CLLocationCoordinate2D:json]
                     radius: radius];


### PR DESCRIPTION
This is a proper fix for #22. Instead of removing the radius options, it will set a default of 50 when radius is undefined (50 meters is also set as default on Android)